### PR TITLE
Pass Errors to User

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,8 +10,9 @@ import (
 
 var (
 	// Global BookWorm
-	Bw        *internal.BookWorm
-	tagFilter string
+	Bw          *internal.BookWorm
+	tagFilter   string
+	verboseMode bool
 )
 
 var rootCmd = &cobra.Command{
@@ -25,6 +26,10 @@ var rootCmd = &cobra.Command{
 			fmt.Printf("Alas, there's been an error: %v", err)
 		}
 	},
+}
+
+func init() {
+	rootCmd.PersistentFlags().BoolVarP(&verboseMode, "verbose", "v", false, "Enable verbose output")
 }
 
 func Execute() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,21 +19,35 @@ var rootCmd = &cobra.Command{
 	Use:     "bookworm",
 	Short:   "Bookworm can manage your bookmarks from the command line.",
 	PreRunE: prGetCfg,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		m := TeaModel()
 		p := tea.NewProgram(m)
 		if _, err := p.Run(); err != nil {
-			fmt.Printf("Alas, there's been an error: %v", err)
+			if verboseMode {
+				fmt.Println("Failed to run bubbletea!")
+			}
+			return err
 		}
+		return nil
 	},
 }
 
 func init() {
 	rootCmd.PersistentFlags().BoolVarP(&verboseMode, "verbose", "v", false, "Enable verbose output")
+	rootCmd.SilenceErrors = true
+	if verboseMode {
+		rootCmd.SilenceUsage = true
+	}
 }
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println("Something Horrible Happened!", err)
+		fmt.Println("Failed to execute the root command!")
+		if !verboseMode {
+			fmt.Println("Use the --verbose flag for more information ")
+		}
+		if verboseMode {
+			fmt.Println(err)
+		}
 	}
 }

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -18,8 +18,8 @@ func prGetCfg(_ *cobra.Command, _ []string) error {
 	if err != nil {
 		fmt.Println("Couldn't get config!")
 		fmt.Println("Run bookworm init to initialize the config.")
-		fmt.Println("If you believe this is an error use the --verbose flag.")
 		if !verboseMode {
+			fmt.Println("Use the --verbose flag for more information")
 			os.Exit(2)
 		}
 		return err
@@ -29,9 +29,14 @@ func prGetCfg(_ *cobra.Command, _ []string) error {
 
 func prInitCfg(cmd *cobra.Command, args []string) error {
 	var err error
+	if verboseMode {
+		fmt.Println("Initing config...")
+	}
 	Bw, err = internal.Init()
 	if err != nil {
-		fmt.Println("Failed to create config!")
+		if verboseMode {
+			fmt.Println("Recieved error during init config:", err)
+		}
 		return err
 	}
 	return nil

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -28,7 +28,6 @@ func prInitCfg(cmd *cobra.Command, args []string) error {
 	Bw, err = internal.Init()
 	if err != nil {
 		fmt.Println("Failed to create config!")
-		os.Exit(2)
 		return err
 	}
 	return nil

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -16,8 +16,12 @@ func prGetCfg(_ *cobra.Command, _ []string) error {
 	var err error
 	Bw, err = internal.Get()
 	if err != nil {
-		fmt.Println("Couldn't get Config, please run bookworm init!")
-		os.Exit(2)
+		fmt.Println("Couldn't get config!")
+		fmt.Println("Run bookworm init to initialize the config.")
+		fmt.Println("If you believe this is an error use the --verbose flag.")
+		if !verboseMode {
+			os.Exit(2)
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
Closes #9. I've added the verbose flag so that we could also look at the error coming from `prGetCfg`, which I don't want errors to be dumped out of by default. I think it makes sense for the init config to error out by default if it fails... because it shouldn't.