### PR TITLE
Fix Fresh Init

### DIFF
--- a/internal/util.go
+++ b/internal/util.go
@@ -102,19 +102,20 @@ func getConfigDir(pathTo string) string {
 // This will write to $pathTo+config.yml
 func initConfig(pathTo string) (*Config, error) {
 	pathTo = getConfigDir(pathTo)
-	configInfo, err := os.Stat(pathTo)
-	// Create the config.yml if it's not there
+	configDirInfo, err := os.Stat(pathTo)
+	// Create the configDir if it's not there
 	if os.IsNotExist(err) {
 		err = os.Mkdir(pathTo, dirPerms)
 		if err != nil {
 			return nil, err
 		}
+		configDirInfo, err = os.Stat(pathTo)
 	}
 	if err != nil {
 		return nil, err
 	}
-	if !configInfo.IsDir() {
-		return nil, errors.New("Could not find the directory " + pathTo)
+	if !configDirInfo.IsDir() {
+		return nil, errors.New(pathTo + " is not a directory!")
 	}
 	_, err = os.Create(
 		getConfigPath(pathTo),

--- a/internal/util.go
+++ b/internal/util.go
@@ -15,6 +15,7 @@ var (
 	configDir      = os.Getenv("HOME") + "/.config/bookworm/"
 	configFileName = "config.yml"
 	dbFileName     = "worm.db"
+	dirPerms       = os.FileMode(0700)
 	configPerms    = os.FileMode(0666)
 	dbPerms        = os.FileMode(0600)
 )
@@ -104,7 +105,7 @@ func initConfig(pathTo string) (*Config, error) {
 	configInfo, err := os.Stat(pathTo)
 	// Create the config.yml if it's not there
 	if os.IsNotExist(err) {
-		err = os.Mkdir(pathTo, 0666)
+		err = os.Mkdir(pathTo, dirPerms)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Closes #8. This changes the directory permissions to `0700`, if the execute bit isn't set, we can't access the children of that directory... at least in linux [File Permissions -- Arch](https://arc.net/l/quote/jtstzdiv)