### PR TITLE
Fuzzy find with fzf

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,13 +20,17 @@ var rootCmd = &cobra.Command{
 	Short:   "Bookworm can manage your bookmarks from the command line.",
 	PreRunE: prGetCfg,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		m := TeaModel()
-		p := tea.NewProgram(m)
-		if _, err := p.Run(); err != nil {
-			if verboseMode {
-				fmt.Println("Failed to run bubbletea!")
+		if Bw.Cfg.FzfIntegration {
+			return Bw.FzfOpen("")
+		} else {
+			m := TeaModel()
+			p := tea.NewProgram(m)
+			if _, err := p.Run(); err != nil {
+				if verboseMode {
+					fmt.Println("Failed to run bubbletea!")
+				}
+				return err
 			}
-			return err
 		}
 		return nil
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ var (
 	Bw          *internal.BookWorm
 	tagFilter   string
 	verboseMode bool
+	noFzf       bool
 )
 
 var rootCmd = &cobra.Command{
@@ -20,7 +21,7 @@ var rootCmd = &cobra.Command{
 	Short:   "Bookworm can manage your bookmarks from the command line.",
 	PreRunE: prGetCfg,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if Bw.Cfg.FzfIntegration {
+		if Bw.Cfg.FzfIntegration && !noFzf {
 			return Bw.FzfOpen("")
 		} else {
 			m := TeaModel()
@@ -37,6 +38,7 @@ var rootCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.Flags().BoolVar(&noFzf, "no-fzf", false, "skip the fzf integration")
 	rootCmd.PersistentFlags().BoolVarP(&verboseMode, "verbose", "v", false, "Enable verbose output")
 	rootCmd.SilenceErrors = true
 	if verboseMode {

--- a/internal/fzf.go
+++ b/internal/fzf.go
@@ -1,0 +1,36 @@
+package internal
+
+import (
+	"os"
+	"os/exec"
+)
+
+// Uses Fzf to open a BookMark
+// Inspo https://github.com/zk-org/zk/blob/dev/internal/adapter/fzf/fzf.go
+func (b BookWorm) FzfOpen(tagFilter string) error {
+	fzfExec, err := exec.LookPath("fzf")
+	if err != nil {
+		return err
+	}
+	fzf := exec.Command(fzfExec)
+	rPipe, wPipe, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer wPipe.Close()
+	defer rPipe.Close()
+
+	for _, s := range b.ListBookMarks(tagFilter) {
+		_, err = wPipe.WriteString(s.Name)
+		if err != nil {
+			return err
+		}
+	}
+	// This works with stdin, but not a pipe... why?
+	fzf.Stdin = rPipe //os.Stdin
+	fzfStdOut, err := fzf.Output()
+	if err != nil {
+		return err
+	}
+	return OpenURL(string(fzfStdOut))
+}

--- a/internal/util.go
+++ b/internal/util.go
@@ -18,11 +18,13 @@ var (
 	dirPerms       = os.FileMode(0700)
 	configPerms    = os.FileMode(0666)
 	dbPerms        = os.FileMode(0600)
+	verboseMode    = false
 )
 
 type Config struct {
-	DbPath     string `json:"dbpath"`
-	LastOpened string `json:"lastopened"`
+	DbPath         string `json:"dbpath"`
+	LastOpened     string `json:"lastopened"`
+	FzfIntegration bool   `json:"fzf"`
 }
 
 func (c *Config) writeConfig(pathTo string) error {
@@ -123,9 +125,15 @@ func initConfig(pathTo string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	var fzfThere = false
+	fzf, _ := exec.LookPath("fzf")
+	if fzf != "" {
+		fzfThere = true
+	}
 	cfg := &Config{
-		DbPath:     getDbPath(pathTo),
-		LastOpened: "nothing... yet",
+		DbPath:         getDbPath(pathTo),
+		LastOpened:     "nothing... yet",
+		FzfIntegration: fzfThere,
 	}
 	err = cfg.writeConfig(pathTo)
 	return cfg, err


### PR DESCRIPTION
This adds the initial integration with fzf. A good start for #11. Will need to follow up with fleshing this out a bit. @williambdean I would be interested if you could give some feedback. To enable the integration, you can just run `bookworm init` again (don't worry, it won't wipe your db). If you have fzf installed & it's in your path, it should enable the fzf option in the `~/.config/bookworm/config.yml`.